### PR TITLE
ci: add env-test ci/cd workflow and fix smoke build dns issues

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,114 @@
+name: CI-CD Pipeline
+
+on:
+  push:
+    branches: [ env-test ]
+    tags: [ 'v*.*.*' ]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # build wheel from source and install it (no editable)
+      - name: install project + test deps (wheel-based)
+        run: |
+          python -m pip install -U pip build
+          python -m build --sdist --wheel
+          pip install dist/*.whl
+          pip install ruff mypy pytest pytest-cov pytest-mock
+
+      - name: run tests (use pytest.ini addopts)
+        run: python -m pytest -q
+
+      - name: upload html report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: htmlcov
+          path: htmlcov
+          if-no-files-found: ignore
+
+  build:
+    needs: test
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: build sdist + wheel
+        run: |
+          python -m pip install -U pip build
+          python -m build --sdist --wheel
+      - name: upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+
+  smoke:
+    needs: build
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - name: offline install from dist
+        run: |
+          ls -lah dist
+          python -m pip install --no-index --no-deps dist/*.whl
+      - name: smoke test
+        run: python -c "import mug; print(mug.__version__)"
+
+  deploy:
+    needs: [ build, smoke ]
+    if: github.ref == 'refs/heads/env-test' || startsWith(github.ref, 'refs/tags/v')
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: validate pyproject.toml version matches tag
+        run: |
+          TAG_VERSION="${GITHUB_REF##*/}"
+          PY_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "v$PY_VERSION" != "$TAG_VERSION" ]; then
+            echo "version mismatch: pyproject.toml ($PY_VERSION) != tag (${TAG_VERSION#v})"
+            exit 1
+          fi
+
+      - name: install publish deps
+        run: |
+          python -m pip install -U pip twine
+
+      - name: upload to pypi
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: python -m twine upload dist/*

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -2,25 +2,26 @@ name: smoke
 
 on:
   push:
-    branches-ignore:
-      - env-test
+    branches-ignore: [ env-test ]
+    tags-ignore: [ '**' ]
   pull_request:
-    branches:
-      - env-test
+    branches: [ env-test ]
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   smoke:
-    runs-on: [self-hosted, Linux, ARM64]
+    runs-on: [ self-hosted, Linux, ARM64 ]
 
     steps:
-      - name: checkout
+      - name: Checkout
         uses: actions/checkout@v4
 
-      - name: setup buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: set up python venv for pytest
+      # Minimal pytest setup (mirrors your original flow)
+      - name: Ensure pytest is available
         shell: bash
         run: |
           set -euo pipefail
@@ -30,8 +31,28 @@ jobs:
           .venv/bin/python -m pip install --upgrade pip
           .venv/bin/python -m pip install pytest
 
-      - name: docker build (buildx)
-        run: docker buildx build --load --progress=plain -t mug/dev:ci -f docker/Dockerfile .
+      # Use Buildx with host networking so buildkitd inherits host DNS/egress
+      - name: Set up Buildx (host network)
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
+
+      # Retry wrapper for transient network hiccups
+      - name: docker build (buildx) with retry
+        shell: bash
+        run: |
+          set -euo pipefail
+          tries=4
+          for i in $(seq 1 $tries); do
+            if docker buildx build --load --progress=plain \
+                 -t mug/dev:ci -f docker/Dockerfile .; then
+              exit 0
+            fi
+            echo "Build attempt $i failed. Retrying..."
+            sleep $((5 * i))
+          done
+          echo "Build failed after $tries attempts."
+          exit 1
 
       - name: docker run --help
         run: docker run --rm mug/dev:ci
@@ -40,7 +61,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "sha=${{ github.sha }}"
+          echo "sha=${GITHUB_SHA}"
           ls -R tests || true
           ls -R tests/docker || true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mug"
-version = "0.0.3"
+version = "0.0.4"
 description = "env-test branch: environment smokes for mug"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
- introduce dedicated `ci-cd.yml` workflow for env-test branch • run tests, build artifacts, smoke-test install, and deploy to pypi • add concurrency control and deploy guard for env-test/tags
- update `smoke.yml` • add tags-ignore and concurrency • switch buildx to use host networking to fix dns timeouts • add retry loop around docker build for resilience
- bump project version to 0.0.4