### PR TITLE
ci: add portable commit message linting and local husky enforcement

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,76 @@
+name: commitlint
+
+on:
+  push:
+    branches: ['**']   # all branches (env-test, main, others)
+    tags:     ['**']   # all tags
+  pull_request:
+    branches: ['**']   # all PRs
+  workflow_dispatch:
+
+jobs:
+  commitlint:
+    runs-on: self-hosted  # keep your self-hosted label(s)
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # we need history to compute ranges
+
+      - run: npm i --no-fund --no-audit
+
+      - name: Lint commit messages (push/PR/tag aware)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ZEROES=0000000000000000000000000000000000000000
+
+          if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == refs/tags/* ]]; then
+            # ---- TAG PUSH ----
+            TO="${GITHUB_SHA}"
+            # Try the parent of the tagged commit; if none, fall back to just the tag commit
+            FROM="$(git rev-list -n 1 "${TO}~1" 2>/dev/null || true)"
+            if [[ -z "${FROM}" ]]; then
+              echo "From: (none; first commit?)"
+              echo "To:   ${TO}"
+              echo "No previous commit detected for tag, skipping commitlint."
+              exit 0
+            fi
+            echo "From: ${FROM}"
+            echo "To:   ${TO}"
+            npx commitlint --from "${FROM}" --to "${TO}" --config config/node/commitlint.config.js
+
+          elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            # ---- REGULAR PUSH ----
+            FROM="${{ github.event.before }}"
+            TO="${{ github.sha }}"
+            echo "From: ${FROM}"
+            echo "To:   ${TO}"
+            if [[ "${FROM}" == "${ZEROES}" ]]; then
+              echo "No previous commit detected, skipping commitlint."
+              exit 0
+            fi
+            npx commitlint --from "${FROM}" --to "${TO}" --config config/node/commitlint.config.js
+
+          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            # ---- PR ----
+            FROM="${{ github.event.pull_request.base.sha }}"
+            TO="${{ github.event.pull_request.head.sha }}"
+            echo "From: ${FROM}"
+            echo "To:   ${TO}"
+            # Base SHA should exist for PRs; if ever missing, just skip
+            if [[ -z "${FROM}" || "${FROM}" == "${ZEROES}" ]]; then
+              echo "No valid base SHA for PR, skipping commitlint."
+              exit 0
+            fi
+            npx commitlint --from "${FROM}" --to "${TO}" --config config/node/commitlint.config.js
+
+          else
+            # ---- MANUAL / OTHER ----
+            FROM="HEAD~20"
+            TO="HEAD"
+            echo "From: ${FROM}"
+            echo "To:   ${TO}"
+            npx commitlint --from "${FROM}" --to "${TO}" --config config/node/commitlint.config.js
+          fi

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+npx --no -- commitlint --config config/node/commitlint.config.js --edit "${1}"

--- a/config/node/commitlint.config.js
+++ b/config/node/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = { extends: ["@commitlint/config-conventional"] };

--- a/config/node/conventional-changelogrc.js
+++ b/config/node/conventional-changelogrc.js
@@ -1,0 +1,70 @@
+// .conventional-changelogrc.js
+const TYPE_PREFIX_RE =
+  /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(!:)?(\([^)]+\))?:\s*/i;
+const MD_LINK_RE = /\[([^\]]*?)\]\((?:[^)]+)\)/g;
+
+module.exports = {
+  writerOpts: {
+    // Never autolink issues/PRs
+    linkReferences: false,
+
+    // Render exactly the two sections we want, with "none" fallbacks
+    mainTemplate: [
+      '## {{#if version}}{{version}}{{else}}0.0.0{{/if}} ({{date}})',
+      '',
+      '#### Features',
+      '{{#if features.length}}',
+      '{{#each features}}* {{#if scope}}**{{scope}}:** {{/if}}{{subject}}',
+      '{{/each}}',
+      '{{else}}* none',
+      '{{/if}}',
+      '',
+      '#### Fixes',
+      '{{#if fixes.length}}',
+      '{{#each fixes}}* {{#if scope}}**{{scope}}:** {{/if}}{{subject}}',
+      '{{/each}}',
+      '{{else}}* none',
+      '{{/if}}',
+      ''
+    ].join('\n'),
+
+    // Build the `features` and `fixes` arrays for the template
+    finalizeContext: (context, writerOpts, commits) => {
+      const features = [];
+      const fixes = [];
+      for (const c of commits) {
+        if (c && c.type === 'Features') features.push(c);
+        else if (c && c.type === 'Fixes') fixes.push(c);
+      }
+      context.features = features;
+      context.fixes = fixes;
+      return context;
+    },
+
+    // Keep only feat/fix; strip tag prefixes and any markdown links
+    transform: (c) => {
+      if (!c) return;
+      const commit = { ...c, hash: null, references: [] };
+
+      // map Angular types to our section names
+      if (commit.type === 'feat') commit.type = 'Features';
+      else if (commit.type === 'fix') commit.type = 'Fixes';
+      else return; // drop every other type (docs/chore/ci/etc.)
+
+      if (typeof commit.subject === 'string') {
+        let s = commit.subject.replace(TYPE_PREFIX_RE, ''); // drop "feat:" / "fix(scope):"
+        s = s.replace(MD_LINK_RE, '$1').trim();            // strip any [text](url)
+        commit.subject = s;
+      }
+
+      // also scrub notes just in case (BREAKING CHANGE)
+      if (Array.isArray(commit.notes)) {
+        commit.notes = commit.notes.map(n => ({
+          ...n,
+          text: typeof n.text === 'string' ? n.text.replace(MD_LINK_RE, '$1') : n.text
+        }));
+      }
+      return commit;
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "mug",
+  "private": true,
+  "scripts": {
+    "prepare": "husky",
+    "changelog": "pwsh -NoProfile -File scripts/changelog/changelog.ps1"
+  },
+  "devDependencies": {
+    "@commitlint/cli": "^19.8.1",
+    "@commitlint/config-conventional": "^19.8.1",
+    "conventional-changelog-angular": "^8.0.0",
+    "conventional-changelog-cli": "^5.0.0",
+    "husky": "^9.1.7"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mug"
-version = "0.0.4"
+version = "0.0.5"
 description = "env-test branch: environment smokes for mug"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
- add `.github/workflows/commitlint.yml` with unified triggers for `push`, `pull_request`, and tags and compute the lint range per event with an all-zeros guard; run on `self-hosted` and lint via `npx commitlint --from ... --to ... --config config/node/commitlint.config.js`
- add `.husky/commit-msg` hook for husky v9+ that runs `npx --no -- commitlint --config config/node/commitlint.config.js --edit "${1}"`
- add `config/node/commitlint.config.js` to extend `@commitlint/config-conventional`
- add `config/node/conventional-changelogrc.js` to render only features and fixes and strip type prefixes and markdown links
- add minimal `package.json` with `private` plus `prepare` and `changelog` scripts and `devDependencies` for `@commitlint/cli`, `@commitlint/config-conventional`, `conventional-changelog-cli`, `conventional-changelog-angular`, and `husky`
- update `pyproject.toml` version from `0.0.4` to `0.0.5`