### PR TITLE
ci: restore deploy job to publish artifacts to PyPI

### DIFF
--- a/.github/workflows/ci-tag.yml
+++ b/.github/workflows/ci-tag.yml
@@ -100,3 +100,38 @@ jobs:
       - name: smoke test (import + where)
         shell: bash
         run: |
+
+  deploy:
+    needs: [ smoke ]
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - name: validate pyproject.toml version matches tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${GITHUB_REF##*/}"          # e.g. v0.1.2
+          PY_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [[ "v${PY_VERSION}" != "${TAG_VERSION}" ]]; then
+            echo "version mismatch: pyproject.toml (${PY_VERSION}) != tag (${TAG_VERSION#v})"
+            exit 1
+          fi
+      - name: install publish deps
+        run: |
+          set -euo pipefail
+          python -m pip install -U pip twine
+      - name: upload to pypi
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          python -m twine upload dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mug"
-version = "0.0.5"
+version = "0.0.6"
 description = "env-test branch: environment smokes for mug"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
- re-added the missing `deploy` job to the CI/CD workflow.
- this step validates the `pyproject.toml` version against the tag and uploads the built distributions to PyPI using twine.