### PR TITLE
feat: introduce modular DI composition root and system/documents modules with CLI

### DIFF
--- a/docs/TESTING_POLICY.md
+++ b/docs/TESTING_POLICY.md
@@ -1,71 +1,141 @@
-# 🧪 Testing Policy
+# Testing Policy
 
-## 1. Correctness
+## 🧠 Myth-busting
 
-* Tests must run in CI.
+**1) Requirements live in one big document**  
+_Myth:_ Requirements belong in a single, definitive specification.  
+_Reality:_ In practice, requirements spread across tests, code, configuration, runtime behavior, and some prose. Forcing them into one document creates blind spots and slows adaptation.
+
+**2) Duplication works fine if we keep things in sync**  
+_Myth:_ Requirements can safely be repeated in different formats, as long as we maintain them.  
+_Reality:_ Duplicates always drift apart. The safest approach is to define a single **source of truth** (commonly automated acceptance tests) and generate other views from it.
+
+**3) Quality equals matching the requirements**  
+_Myth:_ A product is “high quality” if it conforms to documented requirements.  
+_Reality:_ Quality means **acceptance by users and stakeholders**. Passing automated acceptance tests proves fitness-for-purpose more reliably than matching documents.
+
+**4) The code alone is sufficient**  
+_Myth:_ Code fully expresses the system’s requirements.  
+_Reality:_ Code shows _what_ the system does, but not _why_ or _for whom_. Automated tests capture expected outcomes, while lightweight architectural rules preserve long-term intent.
+
+**5) More documents guarantee more quality**  
+_Myth:_ The more documentation we write, the safer the system becomes.  
+_Reality:_ Extra documents usually add more chances for drift. Small, **automated, enforceable artifacts** reduce risk far more effectively than volumes of prose.
+
+**6) Natural language and code are interchangeable**  
+_Myth:_ Any requirement can be expressed equally well in prose or executable code.  
+_Reality:_ Only **measurable behavior** can be automated. Usability, intent, and non-functional needs require prose and collaboration to cover what executable checks cannot. Conversely, when behavior _is_ measurable, executable checks are the most reliable way to capture and enforce it.
+
+
+**7) Prose is the best way to prove coverage**  
+_Myth:_ Traceability documents are the most reliable way to show compliance.  
+_Reality:_ **Machine-readable links** (tags, dashboards, coverage matrices) scale better and are easier to verify. Prose provides context, but compliance is stronger when tied to automation.
+
+
+
+👉 **Bottom line:**  
+Quality does not come from piles of documents. It comes from **automated, minimal, continuously validated checks**. Yet not all requirements are measurable. That’s why **tests enforce, prose explains, and collaboration aligns** — together keeping systems trustworthy and users satisfied.
+
+
+* * *
+
+## 📜 Policies
+
+
+
+### 1. Correctness
+
+* Tests run in CI.
+    
 * A change is valid only if its tests pass in CI.
+    
 * If something is not tested in CI, it is not verified.
+    
 
-## 2. CI
+### 2. CI
 
-* The main branch is valid only when CI is green.
+* The `main` branch is valid only when CI is green.
+    
 * Red CI blocks merges and releases.
+    
 * The last change affecting a failing area must investigate.
+    
 
-## 3. Flaky Tests
+### 3. Flaky Tests
 
-* A flaky test (one that passes and fails on the same code) must be quarantined with a tag and ticket.
+* A flaky test (passes and fails on the same code) must be quarantined with a tag and ticket.
+    
 * Quarantines expire after 7 days.
+    
 * Expired quarantines block merges until resolved.
+    
 
-## 4. Bugs
+### 4. Bugs
 
 * A bug fix must include a test that would have detected the bug.
+    
 * That test must reference the bug ID.
+    
 
-## 5. Determinism
+### 5. Determinism
 
 * Tests must be deterministic.
+    
 * Randomness must use fixed seeds.
+    
 * Clocks, networks, and fixtures must be controlled.
+    
 * External calls are allowed only in integration or end-to-end suites.
+    
 
----
+* * *
 
-## 6. Mocking Strategy
+### 6. Mocking Strategy
 
-**Goal:** make unit tests fast, deterministic, and focused by replacing external boundaries with mocks/fakes.
+**Goal:** fast, deterministic, focused unit tests by replacing external boundaries with mocks/fakes.
 
-### 6.1 Tools
+#### 6.1 Tools
 
-* Prefer **pytest-mock** (`mocker` fixture) for patches and spies.
-* Built-in `unittest.mock` is acceptable where convenient.
+* Prefer **pytest-mock** (`mocker` fixture) for patches/spies.
+    
+* `unittest.mock` is acceptable where convenient.
+    
 
-### 6.2 What to mock
+#### 6.2 What to mock
 
-* **External libraries & I/O:** e.g., `xmlschema.XMLSchema`, `iter_errors`, filesystem reads/writes, network, environment, time.
+* **External libraries & I/O:** filesystem, network, environment, time, heavy parsers.
+    
 * **Process interactions:** `sys.exit`, `sys.argv`, `os.environ`.
-* **Slow or nondeterministic code:** random, clocks, background threads.
+    
+* **Slow/nondeterministic code:** randomness, clocks, background threads.
+    
 
-### 6.3 How to patch
+#### 6.3 How to patch
 
-* **Patch where used** (module under test), not where defined:
-
-  * ✅ `mocker.patch("mug.cli.xmlschema.XMLSchema", ...)`
-  * ❌ `mocker.patch("xmlschema.XMLSchema", ...)` (won’t affect already-imported symbols)
+* **Patch where used** (module under test), not where defined.
+    
+    * ✅ `mocker.patch("mug.cli.xmlschema.XMLSchema", ...)`
+        
+    * ❌ `mocker.patch("xmlschema.XMLSchema", ...)`
+        
 * Use `mocker.Mock()` / `mocker.spy()` to control behavior and assert calls.
+    
 
-### 6.4 Unit vs Integration
+#### 6.4 Unit vs Integration
 
-* **Unit tests:** no real network, no large disk I/O; use mocks/fakes.
-* **Integration/E2E:** allowed to touch real dependencies; mark with `@pytest.mark.integration` (or similar).
+* **Unit:** no real network, no large disk I/O; use mocks/fakes.
+    
+* **Integration/E2E:** real dependencies allowed; mark with `@pytest.mark.integration` (or similar).
+    
 
-### 6.5 Logging & exit codes
+#### 6.5 Logging & exit codes
 
-* Use `caplog` to assert log messages/levels.
+* Use `caplog` to assert logs/levels.
+    
 * Use `pytest.raises(SystemExit)` or patch `sys.exit` to assert exit paths.
+    
 
-### 6.6 Examples (illustrative)
+#### 6.6 Examples (illustrative)
 
 ```python
 def test_validate_ok(mocker, capsys):
@@ -98,69 +168,206 @@ def test_validate_finds_errors(mocker):
     assert _validate("doc.xml", "schema.xsd") == 1
 ```
 
-### 6.7 Fixtures
+#### 6.7 Fixtures
 
-* Put shared fixtures in `tests/conftest.py` (e.g., `repo_root`, temp dirs, common mocks).
-* Use `tmp_path`/`tmp_path_factory` for ephemeral files.
+* Put shared fixtures in `tests/conftest.py` (temp dirs, common mocks).
+    
+* Use `tmp_path` / `tmp_path_factory` for ephemeral files.
+    
 
-### 6.8 Do / Don’t
+#### 6.8 Do / Don’t
 
-* ✅ Do force error paths by raising from mocked dependencies.
-* ✅ Do assert logs and exit codes.
-* ❌ Don’t depend on wall-clock time or network in unit tests.
-* ❌ Don’t import heavy modules in `conftest` that slow collection.
+* ✅ Force error paths by raising from mocked dependencies.
+    
+* ✅ Assert logs and exit codes.
+    
+* ❌ Depend on wall-clock time or the network in unit tests.
+    
+* ❌ Import heavy modules in `conftest` that slow collection.
+    
 
----
+* * *
 
+### 7. Coverage Policy
 
-## 7. Coverage Policy
+**Goal:** prevent regressions with a hard coverage floor locally and in CI.
 
-**Goal:** prevent regressions by enforcing a hard coverage floor in local runs and CI.
+* **Local gate:** run with coverage and fail under the threshold.  
+    _Recommended_: `pytest -q --cov=src --cov-report=term-missing --cov-fail-under=100`
+    
+* **CI gate:** the same floor is enforced in CI; PRs that reduce coverage fail.
+    
+* **Exceptions:** truly unreachable lines use `# pragma: no cover` with justification in review.
+    
 
-* **Local gate:** run tests with coverage and fail if below threshold.
+_Example (GitHub Actions):_
 
-  * Recommended: `pytest -q --cov=src --cov-report=term-missing --cov-fail-under=100`.
-* **CI gate:** the coverage floor is enforced in CI; PRs that reduce coverage fail the build.
+```yaml
+- name: Test (pytest + coverage)
+  run: |
+    pytest -q --cov=src --cov-report=term-missing --cov-fail-under=100
+- name: Coverage artifacts (optional)
+  if: always()
+  run: |
+    pytest --cov=src --cov-report=html --cov-report=xml:coverage.xml --cov-fail-under=100
+```
 
-  * Example (GitHub Actions):
+* * *
 
-    ```yaml
-    - name: Test (pytest + coverage)
-      run: |
-        pytest -q --cov=src --cov-report=term-missing --cov-fail-under=100
-    - name: Coverage artifacts (optional)
-      if: always()
-      run: |
-        pytest --cov=src --cov-report=html --cov-report=xml:coverage.xml --cov-fail-under=100
-    ```
-* **Exceptions:** if a line is truly unreachable by design, annotate with `# pragma: no cover` and justify in code review.
+### 8. Smoke Tests
 
----
+**Goal:** catch packaging/CLI regressions quickly with a tiny, fast suite.
 
-## 8. Smoke Tests
+* **Scope:** basic CLI availability and core commands:
+    
+    * `mug --version` prints SemVer string and exits 0.
+        
+    * `mug help` prints module commands.
+        
+    * `mug documents trace-id` prints UUIDv4 and exits 0.
+        
+    * `mug documents db build|info|drop|rebuild` succeed in sequence.
+        
+* **Location:** `tests/smoke/` (collected in CI).
+    
+* **Runtime:** < 10s total; no network; uses ephemeral temp dirs.
+    
 
-TODO
+_Minimal pytest example:_
 
-## 9. Import Linter
+```python
+import json, re, subprocess
 
-TODO
+def run(*args):
+    cp = subprocess.run(["mug", *args], capture_output=True, text=True)
+    return cp.returncode, cp.stdout.strip()
 
-## 10. The `env-test` Branch
+def test_version():
+    rc, out = run("--version")
+    assert rc == 0 and re.match(r"^\d+\.\d+\.\d+(?:[-+].+)?$", out)
 
-TODO
+def test_help_lists_documents():
+    rc, out = run("help")
+    assert rc == 0 and "documents: trace-id, add, db" in out
 
----
+def test_trace_id():
+    rc, out = run("documents", "trace-id")
+    assert rc == 0 and re.match(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$", out)
 
-## CI Enforcement Recap
+def test_documents_db_lifecycle(tmp_path, monkeypatch):
+    # Optional: point config to temp workspace if supported
+    rc, _ = run("documents", "db", "build");    assert rc == 0
+    rc, out = run("documents", "db", "info");   assert rc == 0 and json.loads(out)["meta"]["schema_version"] == "1"
+    rc, _ = run("documents", "db", "drop");     assert rc == 0
+    rc, _ = run("documents", "db", "rebuild");  assert rc == 0
+```
 
+* * *
 
-* **Lint:** Ruff runs with repo‑root `ruff.toml`; tests exclude paths as configured.
-* **Types:** mypy runs in CI with strictness appropriate for the codebase.
-* **Tests:** pytest executes unit & integration suites; requirement markers are honored.
-* **Coverage Gate:** CI fails if `--cov-fail-under` is breached; HTML/XML reports are archived as artifacts.
-* **Smoke Test:** TODO
-* **Import Linter:** TODO
-* **The `env-test` Branch:** TODO
+### 9. Import Linter
 
+**Goal:** enforce Clean Architecture and modular boundaries at import time.
 
+* **Tool:** [`import-linter`](https://github.com/seddonym/import-linter?utm_source=chatgpt.com)
+    
+* **Policy:** encode contracts that reflect layers and modules. Adjust package names to your actual importable packages.
+    
 
+_Example `.importlinter` (tune to your package layout):_
+
+```
+[importlinter]
+root_package = mug
+
+[contract:ca-layering]
+name = Clean Architecture layering
+type = layers
+layers =
+    mug.common.domain
+    mug.common.application
+    mug.modules.system.domain
+    mug.modules.system.application
+    mug.modules.documents.application
+    mug.modules.system.presentation
+    mug.modules.documents.presentation
+    mug.common.infrastructure
+    mug.modules.system.infrastructure
+    mug.modules.documents.infrastructure
+
+[contract:modules-isolation]
+name = Modules do not reach into each other’s internals
+type = independence
+modules =
+    mug.modules.system
+    mug.modules.documents
+```
+
+* **CI:** add a step that runs `lint-imports` (or `lint-imports --no-cache`) and fails on violation.
+    
+
+* * *
+
+### 10. The `env-test` Branch
+
+**Goal:** harden the app across environments without slowing `main` CI.
+
+* **Branch:** `env-test` tracks `main` (rebased/merged regularly).
+    
+* **Matrix:** runs extended tests across OS / Python versions (e.g., `ubuntu-latest`, `macOS-latest`; Python `3.x` matrix).
+    
+* **Scope:** slow E2E, filesystem quirks, locale/timezone variance, large fixture sets, SQLite locking behavior.
+    
+* **Gating:**
+    
+    * `main` merges are blocked only by the standard CI gates (tests/coverage/import-linter).
+        
+    * **Releases** require a green `env-test` run within the last 48 hours (automation checks the latest workflow run).
+        
+* **Quarantine:** flaky tests in `env-test` follow the same 7-day quarantine policy.
+    
+
+_Example GH Actions sketch:_
+
+```yaml
+name: Env Test
+on:
+  push:
+    branches: [env-test]
+  schedule:
+    - cron: "0 6 * * *"  # daily
+jobs:
+  matrix-tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: ${{ matrix.python }} }
+      - run: pip install -e ".[dev]"
+      - run: pytest -q -m "integration or e2e" --maxfail=1
+```
+
+* * *
+
+## 🔒 CI Enforcement Recap
+
+* **Lint:** Ruff runs via repo `ruff.toml`; test paths excluded as configured.
+    
+* **Types:** mypy runs with agreed strictness.
+    
+* **Tests:** pytest executes unit & integration suites; markers honored.
+    
+* **Coverage Gate:** `--cov-fail-under=100` enforced locally and in CI.
+    
+* **Smoke Tests:** always on; must pass in CI.
+    
+* **Import Linter:** enforced in CI; fails on layer/module violations.
+    
+* **Env Test:** separate branch & nightly matrix; green within 48h required for release.
+    
+
+* * *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,12 @@ version = "0.3.0"
 description = "XML Schema (XSD 1.0/1.1) validation CLI."
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = []  # no runtime deps
+dependencies = [
+  "dependency-injector>=4.41",
+  "typer>=0.12",
+  "pydantic>=2.6",
+  "sqlalchemy>=2.0"
+]
 license = { file = "LICENSE" }
 classifiers = [
   "Programming Language :: Python :: 3",
@@ -37,6 +42,7 @@ test = [
   "ruff>=0.4",
   "import-linter>=2.0",
   "pyyaml>=6.0",
+  "typer[all]>=0.12"
 ]
 
 [tool.pytest.ini_options]

--- a/src/mug/cli/__main__.py
+++ b/src/mug/cli/__main__.py
@@ -1,14 +1,118 @@
+"""
+CLI composition root for Mug.
+
+- Loads configuration (env-first, optional JSON overlay via MUG_CONFIG=<path>).
+- Builds the DI container and plugs in Common + Module entries.
+- Exposes root-level CLI commands and mounts module subcommands.
+
+This mirrors the .NET golden example’s “*Module” entry points by calling
+`add_system_module(...)` and `add_documents_module(...)` from each module’s
+Infrastructure layer.
+"""
+
 from __future__ import annotations
 
-# stdlib / typing imports go here if/when needed, AFTER the blank line above.
-# Example (keep alphabetical, one group, no local imports mixed in):
-# import argparse
-# from typing import Sequence
+import json
+import os
+from pathlib import Path
+from typing import Any
 
-def main(argv: list[str] | None = None) -> int:
-    # ...existing CLI logic...
-    return 0
+import typer
+
+from mug.cli.container import AppContainer
+from mug.cli.help_catalog import StaticCommandCatalog
+
+# CA-layer bootstraps (contracts + infrastructure)
+from mug.common.application.bootstrap import add_common_application
+from mug.common.infrastructure.bootstrap import add_common_infrastructure
+
+# Module composition entries (analogue to IServiceCollection extension methods)
+from mug.modules.system.infrastructure.system_module import add_system_module
+from mug.modules.documents.infrastructure.documents_module import add_documents_module
+
+# Use case DTOs
+from mug.modules.system.application.version.get_version.query import GetVersionQuery
+
+
+app = typer.Typer(no_args_is_help=True, add_completion=False)
+
+
+def _load_config() -> dict[str, Any]:
+    """Env-first config with optional JSON overlay via MUG_CONFIG=<path>."""
+    cfg_path = os.environ.get("MUG_CONFIG", "")
+    data: dict[str, Any] = {
+        "logging": {"level": os.environ.get("LOG_LEVEL", "INFO")},
+        "modules": {
+            # documents module DB defaults (ephemeral by default)
+            "documents": {"db": {"mode": "ephemeral", "path": None}},
+            "system": {},
+        },
+    }
+    if cfg_path and Path(cfg_path).is_file():
+        data |= json.loads(Path(cfg_path).read_text())
+    return data
+
+
+def _compose() -> AppContainer:
+    """Build DI root, register common + modules, initialize logging."""
+    c = AppContainer()
+    c.config.from_dict(_load_config())
+
+    # Common bootstraps (contracts first, then infrastructure)
+    add_common_application(c)
+    add_common_infrastructure(c, log_level=c.config.logging.level())
+
+    # Composition-root–owned catalog (prevents System from knowing other modules)
+    catalog = StaticCommandCatalog(
+        {
+            "documents": ["trace-id", "add", "db"],
+        }
+    )
+
+    # Plug modules (IServiceCollection-style)
+    add_system_module(c, command_catalog=catalog)
+    add_documents_module(c)
+
+    # Initialize logging once at startup
+    c.logging_initializer().initialize()
+    return c
+
+
+_container = _compose()
+
+
+@app.callback()
+def _root_cb(
+    version: bool = typer.Option(
+        False, "--version", "-v", is_eager=True, help="Show version and exit."
+    )
+) -> None:
+    if version:
+        handler = _container.system().get_version_handler()
+        typer.echo(handler.handle(GetVersionQuery()))
+        raise typer.Exit(0)
+
+
+@app.command("version", help="Show version.")
+def version_cmd() -> None:
+    handler = _container.system().get_version_handler()
+    typer.echo(handler.handle(GetVersionQuery()))
+
+
+@app.command("help", help="Show available module commands.")
+def help_cmd() -> None:
+    handler = _container.system().get_help_handler()
+    typer.echo(handler.handle())
+
+
+# Mount module CLIs
+for subapp in _container.documents().cli_apps():
+    app.add_typer(subapp)
+
+
+def main() -> None:
+    app()
+
 
 if __name__ == "__main__":
-    raise SystemExit(main())
-
+    main()

--- a/src/mug/cli/container.py
+++ b/src/mug/cli/container.py
@@ -1,0 +1,21 @@
+"""Application composition root container (DI).
+
+This container only declares provider placeholders. Concrete bindings are
+applied by Clean Architecture bootstraps (Common.Application / Common.Infrastructure)
+and by per-module registries from the composition root.
+"""
+
+from dependency_injector import containers, providers
+
+
+class AppContainer(containers.DeclarativeContainer):
+    # App configuration (dict-like), loaded in the CLI composition step
+    config = providers.Configuration()
+
+    # Common services (bound by common.infrastructure.bootstrap)
+    clock = providers.Provider()
+    logging_initializer = providers.Provider()
+
+    # Module registries (overridden with module containers in the CLI)
+    system = providers.Provider()
+    documents = providers.Provider()

--- a/src/mug/cli/help_catalog.py
+++ b/src/mug/cli/help_catalog.py
@@ -1,0 +1,21 @@
+"""Composition-root command catalog.
+
+This keeps cross-module knowledge (module -> commands) OUT of modules like
+System. The composition root owns and injects this data via a port.
+"""
+
+from typing import Dict, List, Mapping, Sequence
+
+
+class StaticCommandCatalog:
+    """Simple in-memory implementation of the CommandCatalog port."""
+
+    def __init__(self, mapping: Mapping[str, Sequence[str]] | None = None) -> None:
+        # Normalize to {str: List[str]} and copy to avoid external mutation
+        self._mapping: Dict[str, List[str]] = {
+            str(k): list(v) for k, v in (mapping or {}).items()
+        }
+
+    def list_commands(self) -> Dict[str, List[str]]:
+        """Return a copy of the module -> commands map."""
+        return {k: list(v) for k, v in self._mapping.items()}

--- a/src/mug/common/application/bootstrap.py
+++ b/src/mug/common/application/bootstrap.py
@@ -1,0 +1,18 @@
+"""Common.Application bootstrap.
+
+Wires application-layer contracts and pipelines into the DI container.
+MUST NOT import from Infrastructure or module-specific packages to preserve
+Clean Architecture dependency direction.
+"""
+
+from typing import Any
+
+
+def add_common_application(services: Any) -> None:
+    """Register application-layer services with the container.
+
+    Keep this limited to application-layer concerns (e.g., pipelines, result
+    mappers). Avoid importing concretes from Infrastructure.
+    """
+    # Intentionally empty for now; add application-wide pipelines here later.
+    return None

--- a/src/mug/common/application/paging.py
+++ b/src/mug/common/application/paging.py
@@ -1,0 +1,128 @@
+"""Common.Application: simple paging primitives.
+
+Lightweight, framework-agnostic helpers for pagination. Handlers can return a
+`Page[T]` to Presentation, which can render consistently.
+
+Usage:
+    from mug.common.application.paging import PageRequest, paginate
+
+    req = PageRequest(page=2, size=10)
+    page = paginate(range(53), req)   # works with Sequences and Iterables
+    assert page.page == 2
+    assert page.size == 10
+    assert page.total == 53
+    assert page.items == list(range(10, 20))
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import ceil
+from typing import Generic, Iterable, Iterator, List, Sequence, Tuple, TypeVar
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class PageRequest:
+    """Client paging request.
+
+    Args:
+        page: 1-based page number.
+        size: page size (items per page).
+    """
+    page: int = 1
+    size: int = 50
+
+    def __post_init__(self) -> None:
+        if self.page < 1:
+            raise ValueError("page must be >= 1")
+        if self.size < 1 or self.size > 1000:
+            raise ValueError("size must be in [1, 1000]")
+
+
+@dataclass(frozen=True)
+class Page(Generic[T]):
+    """A single page of items with total count and page metadata."""
+    items: List[T]
+    total: int
+    page: int         # 1-based
+    size: int         # page size
+
+    @property
+    def pages(self) -> int:
+        """Total number of pages (>= 1 when total > 0, else 0)."""
+        return ceil(self.total / self.size) if self.total > 0 else 0
+
+    @property
+    def has_prev(self) -> bool:
+        return self.page > 1 and self.total > 0
+
+    @property
+    def has_next(self) -> bool:
+        return self.page < self.pages
+
+    @property
+    def first_index(self) -> int:
+        """0-based index of first item on this page within the full result set."""
+        return (self.page - 1) * self.size
+
+    @property
+    def last_index(self) -> int:
+        """0-based index of last item on this page within the full result set (inclusive)."""
+        return min(self.first_index + self.size, self.total) - 1 if self.total else -1
+
+    def map(self, fn) -> "Page":
+        """Map items to another type while preserving paging metadata."""
+        return Page(items=[fn(x) for x in self.items], total=self.total, page=self.page, size=self.size)
+
+
+def paginate(data: Sequence[T] | Iterable[T], request: PageRequest) -> Page[T]:
+    """Paginate either a Sequence (supports slicing) or a generic Iterable.
+
+    - For Sequences: O(1) slicing and O(1) total via len().
+    - For Iterables: consumes the iterable to compute total and collect the current page.
+      This is O(n) and should be used for small/finite iterables only.
+
+    Args:
+        data: the collection to paginate.
+        request: paging request (1-based page, size).
+
+    Returns:
+        Page[T]
+    """
+    if isinstance(data, Sequence):
+        return _paginate_sequence(data, request)
+    return _paginate_iterable(iter(data), request)
+
+
+def _paginate_sequence(seq: Sequence[T], req: PageRequest) -> Page[T]:
+    total = len(seq)
+    start = (req.page - 1) * req.size
+    end = start + req.size
+    if start >= total:
+        # empty page beyond the end
+        return Page(items=[], total=total, page=req.page, size=req.size)
+    items = list(seq[start:end])
+    return Page(items=items, total=total, page=req.page, size=req.size)
+
+
+def _paginate_iterable(it: Iterator[T], req: PageRequest) -> Page[T]:
+    """Consume an iterator to compute total and slice the desired page."""
+    start = (req.page - 1) * req.size
+    end = start + req.size
+
+    items: List[T] = []
+    total = 0
+
+    # Single pass: collect only requested window, but still count total.
+    for idx, item in enumerate(it):
+        if start <= idx < end:
+            items.append(item)
+        total += 1
+
+    # If requested page is out of range, return empty with accurate total.
+    if start >= total:
+        items = []
+
+    return Page(items=items, total=total, page=req.page, size=req.size)

--- a/src/mug/common/application/pipeline.py
+++ b/src/mug/common/application/pipeline.py
@@ -1,0 +1,143 @@
+"""Common.Application: handler pipeline utilities.
+
+These decorators/helpers standardize how application handlers execute:
+- Logging around handler execution
+- Converting bare return values into Result[T]
+- Mapping exceptions into Problem envelopes (no stack traces to callers)
+
+They are CA-friendly: depend only on Common.Application and Common.Domain.
+
+Example:
+    from mug.common.application.pipeline import pipeline
+    from mug.common.application.result import Result, ok
+    from mug.common.domain.errors import DomainError
+
+    @pipeline()  # adds logging + exception->Problem mapping + result wrapping
+    def handle(query: GetThingQuery) -> Result[str] | str:
+        if not authorized:
+            raise DomainError(code="NOT_AUTHORIZED", message="...")
+        return ok("value")  # or just "value" and it will be wrapped
+
+    r = handle(GetThingQuery(...))
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Optional, TypeVar, Union, cast
+
+from mug.common.application.result import Err, Ok, Problem, Result, err, ok
+from mug.common.domain.errors import DomainError  # will be provided in a later step
+
+T = TypeVar("T")
+
+
+def ensure_result(value: Union[Result[T], T]) -> Result[T]:
+    """Return value as Result, wrapping non-Result values with Ok."""
+    if isinstance(value, (Ok, Err)):
+        return cast(Result[T], value)
+    return ok(cast(T, value))
+
+
+def default_exception_mapper(ex: Exception) -> Problem:
+    """Map exceptions to a Problem envelope with stable codes/messages."""
+    if isinstance(ex, DomainError):
+        # Domain raised a typed error with a stable code
+        return Problem(code=ex.code, message=ex.message, details=ex.details)
+    if isinstance(ex, ValueError):
+        return Problem(code="VALIDATION_ERROR", message=str(ex))
+    if isinstance(ex, KeyError):
+        return Problem(code="MISSING_KEY", message=str(ex))
+    # Catch-all; avoid leaking internal details
+    return Problem(code="UNEXPECTED_ERROR", message=str(ex) or ex.__class__.__name__)
+
+
+def pipeline(
+    *,
+    logger: Optional[logging.Logger] = None,
+    exception_mapper: Optional[Callable[[Exception], Problem]] = None,
+) -> Callable[[Callable[..., Union[Result[T], T]]], Callable[..., Result[T]]]:
+    """Decorator: add logging + exception→Problem mapping + Result wrapping.
+
+    Args:
+        logger: optional logger; defaults to module/function-based logger.
+        exception_mapper: optional custom mapper; defaults to `default_exception_mapper`.
+
+    Returns:
+        Wrapped callable that always yields `Result[T]`.
+    """
+
+    def decorator(func: Callable[..., Union[Result[T], T]]) -> Callable[..., Result[T]]:
+        log = logger or logging.getLogger(f"{func.__module__}.{func.__qualname__}")
+        map_ex = exception_mapper or default_exception_mapper
+
+        def wrapper(*args: Any, **kwargs: Any) -> Result[T]:
+            log.debug("START %s", func.__name__)
+            try:
+                result = func(*args, **kwargs)
+                wrapped = ensure_result(result)
+                if isinstance(wrapped, Ok):
+                    log.debug("OK %s", func.__name__)
+                else:
+                    p = wrapped.problem
+                    log.warning("ERR %s [%s] %s", func.__name__, p.code, p.message)
+                return wrapped
+            except Exception as ex:  # noqa: BLE001
+                problem = map_ex(ex)
+                log.error("EXC %s [%s] %s", func.__name__, problem.code, problem.message)
+                return err(problem.code, problem.message, problem.details)
+
+        # Preserve useful metadata
+        wrapper.__name__ = getattr(func, "__name__", "wrapped")
+        wrapper.__doc__ = getattr(func, "__doc__", None)
+        wrapper.__qualname__ = getattr(func, "__qualname__", wrapper.__name__)
+        return wrapper
+
+    return decorator
+
+
+def with_logging(
+    logger: Optional[logging.Logger] = None,
+) -> Callable[[Callable[..., Union[Result[T], T]]], Callable[..., Union[Result[T], T]]]:
+    """Decorator: logging only (no exception mapping, no result wrapping)."""
+
+    def decorator(func: Callable[..., Union[Result[T], T]]):
+        log = logger or logging.getLogger(f"{func.__module__}.{func.__qualname__}")
+
+        def wrapper(*args: Any, **kwargs: Any):
+            log.debug("START %s", func.__name__)
+            out = func(*args, **kwargs)
+            log.debug("END %s", func.__name__)
+            return out
+
+        wrapper.__name__ = getattr(func, "__name__", "wrapped")
+        wrapper.__doc__ = getattr(func, "__doc__", None)
+        wrapper.__qualname__ = getattr(func, "__qualname__", wrapper.__name__)
+        return wrapper
+
+    return decorator
+
+
+def map_exceptions(
+    exception_mapper: Optional[Callable[[Exception], Problem]] = None,
+) -> Callable[[Callable[..., Union[Result[T], T]]], Callable[..., Result[T]]]:
+    """Decorator: catch exceptions and convert to Err(Problem)."""
+
+    def decorator(func: Callable[..., Union[Result[T], T]]) -> Callable[..., Result[T]]:
+        map_ex = exception_mapper or default_exception_mapper
+        log = logging.getLogger(f"{func.__module__}.{func.__qualname__}")
+
+        def wrapper(*args: Any, **kwargs: Any) -> Result[T]:
+            try:
+                return ensure_result(func(*args, **kwargs))
+            except Exception as ex:  # noqa: BLE001
+                problem = map_ex(ex)
+                log.error("EXC %s [%s] %s", func.__name__, problem.code, problem.message)
+                return err(problem.code, problem.message, problem.details)
+
+        wrapper.__name__ = getattr(func, "__name__", "wrapped")
+        wrapper.__doc__ = getattr(func, "__doc__", None)
+        wrapper.__qualname__ = getattr(func, "__qualname__", wrapper.__name__)
+        return wrapper
+
+    return decorator

--- a/src/mug/common/application/result.py
+++ b/src/mug/common/application/result.py
@@ -1,0 +1,115 @@
+"""Common.Application: Result/Problem primitives.
+
+Lightweight functional-style result envelope inspired by .NET's Result<T>.
+Handlers can return `Result[T]` instead of raising, and Presentation can render
+success/failure uniformly.
+
+Usage:
+    from mug.common.application.result import Result, ok, err, is_ok, unwrap_or
+
+    def handle(...) -> Result[str]:
+        if bad:
+            return err("DOC_NOT_UNIQUE", "Document title must be unique", {"title": t})
+        return ok("done")
+
+    r = handle(...)
+    if is_ok(r):
+        print(r.value)
+    else:
+        print(r.problem.code, r.problem.message)
+"""
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Generic, Optional, TypeVar, Union
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+
+@dataclass(frozen=True)
+class Problem:
+    """Standard error envelope for application/domain failures."""
+    code: str
+    message: str
+    details: Optional[Dict[str, Any]] = None
+
+
+@dataclass(frozen=True)
+class Ok(Generic[T]):
+    """Successful result."""
+    value: T
+
+
+@dataclass(frozen=True)
+class Err:
+    """Failed result."""
+    problem: Problem
+
+
+# Public result type alias
+Result = Union[Ok[T], Err]
+
+
+# --------- Constructors ---------
+def ok(value: T) -> Ok[T]:
+    """Create a successful Result."""
+    return Ok(value)
+
+
+def err(code: str, message: str, details: Optional[Dict[str, Any]] = None) -> Err:
+    """Create a failed Result with a Problem envelope."""
+    return Err(Problem(code=code, message=message, details=details))
+
+
+# --------- Introspection helpers ---------
+def is_ok(result: Result) -> bool:
+    return isinstance(result, Ok)
+
+
+def is_err(result: Result) -> bool:
+    return isinstance(result, Err)
+
+
+# --------- Unwrap helpers (safe defaults) ---------
+def unwrap(result: Result[T]) -> T:
+    """Return value or raise RuntimeError with Problem info."""
+    if isinstance(result, Ok):
+        return result.value
+    p = result.problem  # type: ignore[attr-defined]
+    raise RuntimeError(f"{p.code}: {p.message}")
+
+
+def unwrap_or(result: Result[T], default: T) -> T:
+    """Return value or a provided default."""
+    return result.value if isinstance(result, Ok) else default
+
+
+# --------- Functional helpers ---------
+def map_value(result: Result[T], fn: Callable[[T], U]) -> Result[U]:
+    """Transform the success value; propagate error unchanged."""
+    if isinstance(result, Ok):
+        try:
+            return ok(fn(result.value))
+        except Exception as ex:  # last-resort guard; don't crash pipeline
+            return err("UNEXPECTED_MAP_ERROR", str(ex))
+    return result  # type: ignore[return-value]
+
+
+def bind(result: Result[T], fn: Callable[[T], Result[U]]) -> Result[U]:
+    """Monadic bind: if ok, call fn(value) -> Result[U]; else propagate Err."""
+    if isinstance(result, Ok):
+        try:
+            return fn(result.value)
+        except Exception as ex:
+            return err("UNEXPECTED_BIND_ERROR", str(ex))
+    return result  # type: ignore[return-value]
+
+
+def map_problem(result: Result[T], fn: Callable[[Problem], Problem]) -> Result[T]:
+    """Transform the Problem of an Err; pass Ok through."""
+    if isinstance(result, Err):
+        try:
+            return Err(fn(result.problem))
+        except Exception as ex:
+            return Err(Problem(code="UNEXPECTED_PROBLEM_MAP_ERROR", message=str(ex)))
+    return result

--- a/src/mug/common/application/time.py
+++ b/src/mug/common/application/time.py
@@ -1,0 +1,14 @@
+"""Common.Application: time contract."""
+
+from typing import Protocol
+from datetime import datetime
+
+
+class Clock(Protocol):
+    """Abstract time source (UTC)."""
+
+    def now(self) -> datetime:
+        """Return current UTC time."""
+
+    def now_iso(self) -> str:
+        """Return current UTC time as an ISO-8601 string."""

--- a/src/mug/common/application/trace.py
+++ b/src/mug/common/application/trace.py
@@ -1,0 +1,10 @@
+"""Common.Application: trace/correlation id contract."""
+
+from typing import Protocol
+
+
+class TraceIdProvider(Protocol):
+    """Abstraction for generating correlation/trace identifiers."""
+
+    def new_trace_id(self) -> str:
+        """Return a new opaque trace id (e.g., UUID4 as a string)."""

--- a/src/mug/common/domain/entity.py
+++ b/src/mug/common/domain/entity.py
@@ -1,0 +1,74 @@
+"""Common.Domain: Entity base class.
+
+- Provides identity-based equality and hashing (by `id` and concrete type)
+- Optional domain event stash with add/pull helpers
+- Designed to play nicely with dataclasses in subclasses:
+  * Subclasses define their own `id` field (e.g., as a dataclass field)
+  * No mandatory `super().__init__()` call required
+"""
+
+from __future__ import annotations
+
+from typing import Any, Generic, List, TypeVar, TYPE_CHECKING
+
+TId = TypeVar("TId")
+
+
+if TYPE_CHECKING:
+    # Forward reference only; actual definition will live in common.domain.events
+    class DomainEvent:  # pragma: no cover - typing aid only
+        pass
+
+
+class Entity(Generic[TId]):
+    """Base for aggregate roots and entities with identity semantics.
+
+    Subclasses are expected to define an `id` attribute (hashable). The base
+    implements:
+      - __eq__/__hash__ by (type, id)
+      - domain event helpers (add_domain_event / pull_domain_events)
+    """
+
+    # --- Identity semantics -------------------------------------------------
+    @property
+    def _identity(self) -> Any:
+        try:
+            return getattr(self, "id")
+        except AttributeError as exc:
+            raise AttributeError(
+                f"{self.__class__.__name__} must define an 'id' attribute "
+                "to use Entity identity semantics."
+            ) from exc
+
+    def __eq__(self, other: object) -> bool:
+        if other is self:
+            return True
+        if other is None or not isinstance(other, self.__class__):
+            return False
+        return self._identity == getattr(other, "id", object())
+
+    def __hash__(self) -> int:
+        # Hash by concrete type + id to avoid collisions across types sharing ids
+        return hash((self.__class__, self._identity))
+
+    def __repr__(self) -> str:  # pragma: no cover - convenience only
+        return f"{self.__class__.__name__}(id={self._identity!r})"
+
+    # --- Domain events (optional) -------------------------------------------
+    # Stored lazily to avoid interfering with dataclass-generated __init__
+    def _event_list(self) -> List["DomainEvent"]:
+        lst = getattr(self, "_Entity__domain_events", None)
+        if lst is None:
+            lst = []
+            setattr(self, "_Entity__domain_events", lst)
+        return lst
+
+    def add_domain_event(self, event: "DomainEvent") -> None:
+        """Record a domain event to be dispatched by the application layer."""
+        self._event_list().append(event)
+
+    def pull_domain_events(self) -> List["DomainEvent"]:
+        """Return and clear the recorded domain events."""
+        events = list(self._event_list())
+        self._event_list().clear()
+        return events

--- a/src/mug/common/domain/errors.py
+++ b/src/mug/common/domain/errors.py
@@ -1,0 +1,51 @@
+"""Common.Domain: domain error types.
+
+A lightweight base exception for domain-level failures with a stable error code.
+Domain model and application services can raise `DomainError(code=..., message=...)`
+instead of generic exceptions. The application pipeline can then translate these
+into a uniform Problem/Result for Presentation.
+
+Usage:
+    from mug.common.domain.errors import DomainError, NotFoundError
+
+    if not doc:
+        raise NotFoundError(code="DOC_NOT_FOUND", message="Document does not exist", details={"id": doc_id})
+    if not is_valid(title):
+        raise DomainError(code="DOC_TITLE_INVALID", message="Title is invalid")
+
+Notes:
+- Keep messages user-friendly; internal details should go in `details`.
+- Error codes should be stable and machine-readable (UPPER_SNAKE_CASE).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+class DomainError(Exception):
+    """Base domain exception with a stable error code and optional details."""
+
+    def __init__(self, *, code: str, message: str, details: Optional[Dict[str, Any]] = None) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+        self.message = message
+        self.details = details
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return f"{self.code}: {self.message}"
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return f"DomainError(code={self.code!r}, message={self.message!r}, details={self.details!r})"
+
+
+class ValidationError(DomainError):
+    """Validation failure in domain rules."""
+
+
+class NotFoundError(DomainError):
+    """Entity/aggregate not found."""
+
+
+class ConflictError(DomainError):
+    """State conflict (e.g., uniqueness, concurrency)."""

--- a/src/mug/common/domain/events.py
+++ b/src/mug/common/domain/events.py
@@ -1,0 +1,35 @@
+"""Common.Domain: domain event base type.
+
+Immutable base class for domain events:
+- UTC timestamp (`occurred_on`) set at creation
+- Optional `correlation_id` for tracing across layers/transactions
+- `event_name` convenience property (defaults to the concrete class name)
+
+Subclasses add their own specific, immutable fields:
+
+    from dataclasses import dataclass
+    from mug.common.domain.events import DomainEvent
+
+    @dataclass(frozen=True)
+    class DocumentAdded(DomainEvent):
+        document_id: str
+        title: str
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class DomainEvent:
+    """Base immutable event raised by the Domain."""
+    occurred_on: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    correlation_id: Optional[str] = None
+
+    @property
+    def event_name(self) -> str:
+        """A stable, human-readable name (defaults to the concrete class name)."""
+        return self.__class__.__name__

--- a/src/mug/common/domain/value_object.py
+++ b/src/mug/common/domain/value_object.py
@@ -1,0 +1,84 @@
+"""Common.Domain: ValueObject base class.
+
+A Value Object is compared by the values of its attributes, not by identity.
+Subclasses SHOULD be defined as `@dataclass(frozen=True)` for immutability,
+but this base works for non-dataclass classes as well.
+
+Features:
+- Equality and hashing by value (class + components tuple)
+- Friendly repr()
+- Helper `components()` to introspect the tuple used for comparisons
+- Helper `copy_with(**changes)` for dataclass-based VOs (uses dataclasses.replace)
+
+Usage (recommended):
+    from dataclasses import dataclass
+    from mug.common.domain.value_object import ValueObject
+
+    @dataclass(frozen=True)
+    class Money(ValueObject):
+        amount: int
+        currency: str
+
+    assert Money(10, "USD") == Money(10, "USD")
+    s = {Money(10, "USD"), Money(10, "USD")}
+    assert len(s) == 1
+"""
+
+from __future__ import annotations
+
+from dataclasses import is_dataclass, fields, replace
+from typing import Any, Tuple
+
+
+class ValueObject:
+    """Base class for DDD Value Objects with value-based equality and hashing."""
+
+    # ---- Equality / Hash by value ------------------------------------------
+    def components(self) -> Tuple[Any, ...]:
+        """Return the tuple of values used for equality/hash.
+
+        - If subclass is a dataclass: returns dataclass field values in field order.
+        - Otherwise: returns public attributes (non-callable, not starting with '_')
+          sorted by attribute name for determinism.
+        """
+        if is_dataclass(self):
+            return tuple(getattr(self, f.name) for f in fields(self))
+        # Fallback for non-dataclass VOs
+        items = []
+        for name, value in self.__dict__.items():
+            if name.startswith("_"):
+                continue
+            if callable(value):
+                continue
+            items.append((name, value))
+        items.sort(key=lambda kv: kv[0])
+        return tuple(v for _, v in items)
+
+    def __eq__(self, other: object) -> bool:
+        if other is self:
+            return True
+        if other is None or other.__class__ is not self.__class__:
+            return False
+        return self.components() == getattr(other, "components")()
+
+    def __hash__(self) -> int:
+        return hash((self.__class__, self.components()))
+
+    def __repr__(self) -> str:  # pragma: no cover - convenience only
+        if is_dataclass(self):
+            parts = ", ".join(f"{f.name}={getattr(self, f.name)!r}" for f in fields(self))
+        else:
+            comps = self.components()
+            parts = ", ".join(repr(c) for c in comps)
+        return f"{self.__class__.__name__}({parts})"
+
+    # ---- Utilities ----------------------------------------------------------
+    def copy_with(self, **changes: Any):
+        """Return a copy with `changes` applied (dataclasses only).
+
+        Raises:
+            TypeError: if the subclass is not a dataclass.
+        """
+        if not is_dataclass(self):
+            raise TypeError(f"{self.__class__.__name__}.copy_with requires a dataclass-based ValueObject")
+        return replace(self, **changes)

--- a/src/mug/common/infrastructure/bootstrap.py
+++ b/src/mug/common/infrastructure/bootstrap.py
@@ -1,0 +1,24 @@
+"""Common.Infrastructure bootstrap.
+
+Binds infrastructure concretes to abstract providers declared in the root DI
+container. Keep this module free of any module-specific imports.
+
+- Clock -> SystemClock
+- LoggingInitializer -> LoggingInitializer(level)
+"""
+
+from dependency_injector import providers
+
+from mug.common.infrastructure.time_system import SystemClock
+from mug.common.infrastructure.logging_init import LoggingInitializer
+
+
+def add_common_infrastructure(services, *, log_level: str = "INFO") -> None:
+    """Register infrastructure implementations into the DI container."""
+    # Time source (UTC)
+    services.clock.override(providers.Factory(SystemClock))
+
+    # Logging initializer (one-time setup at composition root)
+    services.logging_initializer.override(
+        providers.Factory(LoggingInitializer, level=log_level)
+    )

--- a/src/mug/common/infrastructure/logging_init.py
+++ b/src/mug/common/infrastructure/logging_init.py
@@ -1,0 +1,45 @@
+"""Common.Infrastructure: logging initializer.
+
+Sets up application-wide logging with a consistent format and level.
+Intended to be invoked once from the composition root.
+"""
+
+import logging
+from typing import Optional
+
+
+_LEVELS = {
+    "CRITICAL": logging.CRITICAL,
+    "ERROR": logging.ERROR,
+    "WARNING": logging.WARNING,
+    "INFO": logging.INFO,
+    "DEBUG": logging.DEBUG,
+    "NOTSET": logging.NOTSET,
+}
+
+
+class LoggingInitializer:
+    """Idempotent logging bootstrapper."""
+
+    def __init__(self, level: str = "INFO", fmt: Optional[str] = None) -> None:
+        self._level_name = level
+        self._fmt = fmt or "%(asctime)s %(levelname)s [%(name)s] %(message)s"
+
+    def initialize(self) -> None:
+        """Initialize root logger.
+
+        If handlers already exist (e.g., tests or a parent framework configured
+        logging), just adjust levels; otherwise call basicConfig().
+        """
+        level = _LEVELS.get(self._level_name.upper(), logging.INFO)
+        root = logging.getLogger()
+
+        if root.handlers:
+            root.setLevel(level)
+            for h in root.handlers:
+                try:
+                    h.setLevel(level)
+                except Exception:  # pragma: no cover - defensive
+                    pass
+        else:
+            logging.basicConfig(level=level, format=self._fmt)

--- a/src/mug/common/infrastructure/orm/__init__.py
+++ b/src/mug/common/infrastructure/orm/__init__.py
@@ -1,0 +1,14 @@
+"""Common.Infrastructure.ORM utilities (SQLAlchemy).
+
+This package provides small, reusable ORM helpers:
+- new_base(): per-module DeclarativeBase factory with naming conventions
+- UTCDateTime, GUID: portable column types
+
+Import convenience:
+    from mug.common.infrastructure.orm import new_base, UTCDateTime, GUID
+"""
+
+from .factory import new_base
+from .types import UTCDateTime, GUID
+
+__all__ = ["new_base", "UTCDateTime", "GUID"]

--- a/src/mug/common/infrastructure/orm/factory.py
+++ b/src/mug/common/infrastructure/orm/factory.py
@@ -1,0 +1,52 @@
+"""Common.Infrastructure.ORM: Declarative base factory.
+
+Provides `new_base()` which returns a fresh SQLAlchemy DeclarativeBase class
+with:
+- Stable naming conventions (indexes, FKs, PKs, etc.)
+- Automatic snake_case `__tablename__` derived from the class name
+
+Usage (per module):
+    from mug.common.infrastructure.orm import new_base
+
+    Base = new_base()
+
+    class Document(Base):
+        id: Mapped[str] = mapped_column(GUID(), primary_key=True)
+        # -> table name will be "document"
+"""
+
+from __future__ import annotations
+
+import re
+from sqlalchemy import MetaData
+from sqlalchemy.orm import DeclarativeBase, declared_attr
+
+
+def _to_snake(name: str) -> str:
+    """Convert CamelCase -> snake_case, preserving acronyms reasonably."""
+    s1 = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
+    s2 = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s1)
+    return s2.replace("__", "_").lower()
+
+
+def new_base():
+    """Create a new DeclarativeBase with naming conventions and snake_case tables."""
+
+    metadata = MetaData(
+        naming_convention={
+            "ix": "ix__%(table_name)s__%(column_0_label)s",
+            "uq": "uq__%(table_name)s__%(column_0_name)s",
+            "ck": "ck__%(table_name)s__%(constraint_name)s",
+            "fk": "fk__%(table_name)s__%(column_0_name)s__%(referred_table_name)s",
+            "pk": "pk__%(table_name)s",
+        }
+    )
+
+    class Base(DeclarativeBase):
+        metadata = metadata
+
+        @declared_attr.directive
+        def __tablename__(cls) -> str:  # noqa: N805
+            return _to_snake(cls.__name__)
+
+    return Base

--- a/src/mug/common/infrastructure/orm/types.py
+++ b/src/mug/common/infrastructure/orm/types.py
@@ -1,0 +1,68 @@
+"""Common.Infrastructure.ORM: portable SQLAlchemy column types.
+
+- UTCDateTime: timezone-aware UTC datetime storage
+- GUID: 36-char UUID-as-text storage (portable across SQLite, Postgres, etc.)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from sqlalchemy.types import DateTime, String, TypeDecorator
+
+
+class UTCDateTime(TypeDecorator):
+    """Store timezone-aware datetimes normalized to UTC.
+
+    Works with backends that don't enforce timezone awareness (e.g., SQLite).
+    Values are coerced to UTC on bind and returned as UTC-aware on result.
+    """
+
+    impl = DateTime(timezone=True)
+    cache_ok = True
+
+    def process_bind_param(self, value: Optional[datetime], dialect: Any) -> Optional[datetime]:  # noqa: ANN401
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+
+    def process_result_value(self, value: Optional[datetime], dialect: Any) -> Optional[datetime]:  # noqa: ANN401
+        if value is None:
+            return None
+        # Some drivers return naive datetimes even when timezone=True (e.g., SQLite)
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+
+
+class GUID(TypeDecorator):
+    """Store UUID values as 36-character strings (portable).
+
+    Accepts either `uuid.UUID` or `str` on bind and always returns `str`.
+    """
+
+    impl = String(36)
+    cache_ok = True
+
+    def process_bind_param(self, value: Any, dialect: Any) -> Optional[str]:  # noqa: ANN401
+        if value is None:
+            return None
+        try:
+            # Avoid importing uuid at module import time to keep light
+            import uuid  # local import
+            if isinstance(value, uuid.UUID):
+                return str(value)
+            s = str(value)
+            # Validate shape quickly (raise if invalid)
+            uuid.UUID(s)
+            return s
+        except Exception as ex:  # noqa: BLE001
+            raise ValueError(f"Invalid GUID value: {value!r}") from ex
+
+    def process_result_value(self, value: Any, dialect: Any) -> Optional[str]:  # noqa: ANN401
+        if value is None:
+            return None
+        return str(value)

--- a/src/mug/common/infrastructure/time_system.py
+++ b/src/mug/common/infrastructure/time_system.py
@@ -1,0 +1,15 @@
+"""Common.Infrastructure: system clock implementation (UTC)."""
+
+from datetime import datetime, timezone
+
+from mug.common.application.time import Clock
+
+
+class SystemClock(Clock):
+    """Production time source using the OS clock in UTC."""
+
+    def now(self) -> datetime:
+        return datetime.now(tz=timezone.utc)
+
+    def now_iso(self) -> str:
+        return self.now().isoformat()

--- a/src/mug/common/infrastructure/trace_uuid.py
+++ b/src/mug/common/infrastructure/trace_uuid.py
@@ -1,0 +1,12 @@
+"""Common.Infrastructure: UUID-based TraceId provider."""
+
+import uuid
+
+from mug.common.application.trace import TraceIdProvider
+
+
+class UuidTraceIdProvider(TraceIdProvider):
+    """Generates opaque correlation/trace identifiers using UUID4."""
+
+    def new_trace_id(self) -> str:
+        return str(uuid.uuid4())

--- a/src/mug/common/presentation/cli_presenters.py
+++ b/src/mug/common/presentation/cli_presenters.py
@@ -1,0 +1,131 @@
+"""Common.Presentation: CLI presenters for Result/Problem.
+
+Two concrete OutputPorts for CLI scenarios:
+
+- TextPresenter[T]: writes human-friendly lines (default to `print`)
+- JsonPresenter[T]: writes structured JSON (default to `print(json)`)
+
+You can pass a custom `write` callable (e.g., `typer.echo`) and optional value
+formatters. These presenters never raise; they degrade gracefully to string
+representations when values aren't JSON-serializable.
+
+Example:
+    from mug.common.presentation.cli_presenters import TextPresenter, JsonPresenter
+    from mug.common.presentation.output import present
+    from mug.common.application.result import ok, err
+
+    tp = TextPresenter[str](write=typer.echo)
+    present(tp, ok("done"))   # prints: done
+
+    jp = JsonPresenter[str](write=typer.echo)
+    present(jp, err("NOT_FOUND", "Missing thing", {"id": 1}))
+    # prints: {"ok": false, "error": {"code": "NOT_FOUND", "message": "Missing thing", "details": {"id": 1}}}
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, is_dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any, Callable, Generic, Optional, TypeVar
+
+from mug.common.application.result import Problem
+from mug.common.presentation.output import OutputPort
+
+T = TypeVar("T")
+
+# ---------- generic JSON fallback -------------------------------------------
+
+
+def _json_default(o: Any) -> Any:
+    """Best-effort JSON serializer for common Python types."""
+    if isinstance(o, (datetime, date)):
+        return o.isoformat()
+    if isinstance(o, Path):
+        return str(o)
+    if is_dataclass(o):
+        return asdict(o)
+    if hasattr(o, "__dict__"):
+        # last resort: object's dict (non-callables, public attrs)
+        return {k: v for k, v in vars(o).items() if not callable(v) and not k.startswith("_")}
+    return repr(o)
+
+
+# ---------- Text presenter ---------------------------------------------------
+
+
+class TextPresenter(OutputPort[T], Generic[T]):
+    """Human-friendly CLI presenter (plain text lines)."""
+
+    def __init__(
+        self,
+        *,
+        write: Optional[Callable[[str], None]] = None,
+        value_fmt: Optional[Callable[[T], str]] = None,
+        problem_prefix: str = "ERROR: ",
+        problem_details_json: bool = True,
+    ) -> None:
+        self._write = write or (lambda s: print(s, flush=True))
+        self._value_fmt = value_fmt or (lambda v: str(v))
+        self._problem_prefix = problem_prefix
+        self._problem_details_json = problem_details_json
+
+    def present_ok(self, value: T) -> None:
+        try:
+            self._write(self._value_fmt(value))
+        except Exception as ex:  # noqa: BLE001
+            self._write(f"{self._value_fmt.__name__ if hasattr(self._value_fmt,'__name__') else 'value'}: {value!r} (format error: {ex})")
+
+    def present_err(self, problem: Problem) -> None:
+        base = f"{self._problem_prefix}[{problem.code}] {problem.message}"
+        if problem.details:
+            try:
+                if self._problem_details_json:
+                    details = json.dumps(problem.details, default=_json_default, ensure_ascii=False)
+                else:
+                    details = str(problem.details)
+                base = f"{base} | details={details}"
+            except Exception:  # best-effort
+                base = f"{base} | details=<unprintable>"
+        self._write(base)
+
+
+# ---------- JSON presenter ---------------------------------------------------
+
+
+class JsonPresenter(OutputPort[T], Generic[T]):
+    """Structured JSON presenter for automated consumption."""
+
+    def __init__(
+        self,
+        *,
+        write: Optional[Callable[[str], None]] = None,
+        default: Optional[Callable[[Any], Any]] = None,
+        indent: Optional[int] = None,
+    ) -> None:
+        self._write = write or (lambda s: print(s, flush=True))
+        self._default = default or _json_default
+        self._indent = indent
+
+    def present_ok(self, value: T) -> None:
+        payload = {"ok": True, "value": value}
+        try:
+            self._write(json.dumps(payload, default=self._default, ensure_ascii=False, indent=self._indent))
+        except Exception:  # noqa: BLE001
+            # Fallback to repr if value is completely non-serializable
+            self._write(json.dumps({"ok": True, "value": repr(value)}, ensure_ascii=False, indent=self._indent))
+
+    def present_err(self, problem: Problem) -> None:
+        payload = {"ok": False, "error": asdict(problem)}
+        try:
+            self._write(json.dumps(payload, default=self._default, ensure_ascii=False, indent=self._indent))
+        except Exception:  # noqa: BLE001
+            # Fallback to minimal structure
+            self._write(
+                json.dumps(
+                    {"ok": False, "error": {"code": problem.code, "message": problem.message}},
+                    ensure_ascii=False,
+                    indent=self._indent,
+                )
+            )

--- a/src/mug/common/presentation/output.py
+++ b/src/mug/common/presentation/output.py
@@ -1,0 +1,39 @@
+"""Common.Presentation: OutputPort protocol and helpers.
+
+Clean Architecture presenter abstraction:
+- Application use cases produce `Result[T]`.
+- Presentation implements an `OutputPort[T]` to render either the value or a Problem.
+- Use the `present(port, result)` helper to route success/error uniformly.
+
+This module defines only the protocol and tiny helpers.
+Concrete presenters (e.g., CLI text/JSON) live in `common/presentation/cli_presenters.py`.
+"""
+
+from __future__ import annotations
+
+from typing import Generic, Protocol, TypeVar
+
+from mug.common.application.result import Err, Ok, Problem, Result
+
+T = TypeVar("T")
+
+
+class OutputPort(Protocol, Generic[T]):
+    """Presenter contract for rendering a use case result."""
+
+    def present_ok(self, value: T) -> None:
+        """Render a successful outcome."""
+
+    def present_err(self, problem: Problem) -> None:
+        """Render a failure with a structured problem."""
+
+
+def present(port: OutputPort[T], result: Result[T]) -> None:
+    """Dispatch a `Result[T]` to the appropriate OutputPort method."""
+    if isinstance(result, Ok):
+        port.present_ok(result.value)
+    elif isinstance(result, Err):
+        port.present_err(result.problem)
+    else:  # pragma: no cover - defensive guard
+        # Should never happen if handlers return Result[T]
+        port.present_err(Problem(code="UNEXPECTED_RESULT_TYPE", message=str(type(result))))

--- a/src/mug/modules/documents/application/documents/__init__.py
+++ b/src/mug/modules/documents/application/documents/__init__.py
@@ -1,0 +1,5 @@
+"""Documents.Application.Documents package.
+
+Holds application-layer use cases for working with documents (CQRS-style),
+such as GetTraceId and AddDocument command/handlers.
+"""

--- a/src/mug/modules/documents/application/documents/add_document/__init__.py
+++ b/src/mug/modules/documents/application/documents/add_document/__init__.py
@@ -1,0 +1,6 @@
+"""AddDocument use case package.
+
+Defines the command DTO and handler for creating a new document entry.
+For now the handler computes a deterministic XML file path (no I/O), which
+lets us exercise CQRS and composition without committing to storage yet.
+"""

--- a/src/mug/modules/documents/application/documents/add_document/command.py
+++ b/src/mug/modules/documents/application/documents/add_document/command.py
@@ -1,0 +1,8 @@
+"""Documents.Application.Documents.AddDocument: command DTO."""
+
+from pydantic import BaseModel
+
+
+class AddDocumentCommand(BaseModel):
+    title: str
+    body: str | None = None

--- a/src/mug/modules/documents/application/documents/add_document/handler.py
+++ b/src/mug/modules/documents/application/documents/add_document/handler.py
@@ -1,0 +1,41 @@
+"""Documents.Application.Documents.AddDocument handler.
+
+Computes a deterministic XML file path for a new document (no I/O yet).
+This lets us exercise CQRS composition and keep storage concerns separate.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from mug.common.application.time import Clock
+from .command import AddDocumentCommand
+
+
+class AddDocumentHandler:
+    """Return a deterministic XML path for a new document."""
+
+    def __init__(self, clock: Clock, base_dir: str = ".mug-data/documents") -> None:
+        self._clock = clock
+        self._base = Path(base_dir)
+
+    def _slug(self, s: str) -> str:
+        s = (s or "").strip().lower()
+        s = re.sub(r"[^a-z0-9]+", "-", s)
+        s = re.sub(r"(^-|-$)", "", s)
+        return s or "untitled"
+
+    def _stamp(self) -> str:
+        """Produce a filesystem-friendly UTC timestamp from ISO-8601."""
+        iso = self._clock.now_iso()  # e.g., 2025-09-04T12:34:56.789012+00:00
+        # Keep digits and 'T'; strip separators/timezone symbols.
+        return re.sub(r"[^0-9T]", "", iso)
+        # Example -> 20250904T1234567890120000
+
+    def handle(self, cmd: AddDocumentCommand) -> str:
+        slug = self._slug(cmd.title)
+        ts = self._stamp()
+        name = f"{slug}--{ts}.xml"
+        path = (self._base / name).resolve()
+        return str(path)

--- a/src/mug/modules/documents/application/documents/get_trace_id/__init__.py
+++ b/src/mug/modules/documents/application/documents/get_trace_id/__init__.py
@@ -1,0 +1,4 @@
+"""GetTraceId use case package.
+
+Provides a query DTO and handler to generate a new trace/correlation id for
+document-related operations.

--- a/src/mug/modules/documents/application/documents/get_trace_id/handler.py
+++ b/src/mug/modules/documents/application/documents/get_trace_id/handler.py
@@ -1,0 +1,17 @@
+"""Documents.Application.Document.GetTraceId handler.
+
+Generates a new trace/correlation id using the cross-cutting TraceIdProvider.
+"""
+
+from mug.common.application.trace import TraceIdProvider
+from .query import GetTraceIdQuery
+
+
+class GetTraceIdHandler:
+    """Returns a fresh trace id for document-related operations."""
+
+    def __init__(self, trace_ids: TraceIdProvider) -> None:
+        self._trace_ids = trace_ids
+
+    def handle(self, _: GetTraceIdQuery) -> str:
+        return self._trace_ids.new_trace_id()

--- a/src/mug/modules/documents/application/documents/get_trace_id/query.py
+++ b/src/mug/modules/documents/application/documents/get_trace_id/query.py
@@ -1,0 +1,8 @@
+"""Documents.Application.Documents.GetTraceId: query DTO."""
+
+from pydantic import BaseModel
+
+
+class GetTraceIdQuery(BaseModel):
+    """Empty query for symmetry with other use cases."""
+    pass

--- a/src/mug/modules/documents/infrastructure/documents_module.py
+++ b/src/mug/modules/documents/infrastructure/documents_module.py
@@ -1,0 +1,13 @@
+from dependency_injector import providers
+
+from mug.cli.container import AppContainer
+from .registry import DocumentsRegistry  # <-- delegate to canonical registry
+
+def add_documents_module(services: AppContainer) -> None:
+    """Register the Documents module into the root container."""
+    docs = providers.Container(
+        DocumentsRegistry,
+        config=services.config.modules.documents,
+        clock=services.clock,
+    )
+    services.documents.override(docs)

--- a/src/mug/modules/documents/infrastructure/registry.py
+++ b/src/mug/modules/documents/infrastructure/registry.py
@@ -1,0 +1,69 @@
+# src/mug/modules/documents/infrastructure/registry.py
+from __future__ import annotations
+
+from pathlib import Path
+from dependency_injector import containers, providers
+
+from mug.common.application.time import Clock
+from mug.common.infrastructure.trace_uuid import UuidTraceIdProvider
+
+from mug.modules.documents.infrastructure import storage
+from mug.modules.documents.presentation.documents.cli import build_documents_app
+from mug.modules.documents.application.documents.get_trace_id.handler import (
+    GetTraceIdHandler,
+)
+from mug.modules.documents.application.documents.add_document.handler import (
+    AddDocumentHandler,
+)
+
+class DocumentsRegistry(containers.DeclarativeContainer):
+    """Documents module container."""
+    config = providers.Configuration()
+
+    # ---- DB mode/path -------------------------------------------------------
+    db_mode = providers.Callable(
+        lambda m: (m or "ephemeral").lower(),
+        config.db.mode.optional(),
+    )
+    db_path = providers.Callable(
+        lambda mode, p: Path(p)
+        if p
+        else (storage.persistent_path() if mode == "persistent" else storage.default_ephemeral_path()),
+        db_mode,
+        config.db.path.optional(),
+    )
+
+    # ---- Engine & session factory ------------------------------------------
+    engine = providers.Singleton(lambda path: storage.create_engine_for(str(path)), db_path)
+    session_factory = providers.Singleton(lambda eng: storage.session_factory_for(eng), engine)
+
+    # ---- Cross-cutting deps --------------------------------------------------
+    clock = providers.Dependency(instance_of=Clock)
+    trace_ids = providers.Factory(UuidTraceIdProvider)
+
+    # ---- Application handlers -----------------------------------------------
+    get_trace_id_handler = providers.Factory(GetTraceIdHandler, trace_ids=trace_ids)
+    add_document_handler = providers.Factory(AddDocumentHandler, clock=clock)
+
+    # ---- Presentation contribution ------------------------------------------
+    def cli_apps(self):
+        return [
+            build_documents_app(
+                get_trace_id_handler_factory=self.get_trace_id_handler,
+                add_document_handler_factory=self.add_document_handler,
+                registry=self,
+            )
+        ]
+
+    # ---- Storage lifecycle helpers ------------------------------------------
+    def ensure_storage(self) -> None:
+        storage.prepare_schema(self.engine())
+
+    def drop_storage(self) -> None:
+        self.engine().dispose()
+        storage.drop_storage(self.db_path())
+
+    def rebuild_storage(self) -> None:
+        self.engine().dispose()
+        eng = storage.rebuild_storage(self.db_path())
+        self.engine.override(providers.Object(eng))

--- a/src/mug/modules/documents/infrastructure/storage.py
+++ b/src/mug/modules/documents/infrastructure/storage.py
@@ -1,0 +1,157 @@
+"""Documents.Infrastructure: per-module SQLite storage & lifecycle.
+
+This module provides a small, self-contained ORM layer for the Documents module:
+- A module-local Declarative Base (no cross-module coupling)
+- Minimal models: Document, MugMeta (schema metadata)
+- Helpers to create engines/sessions and to prepare/read schema metadata
+- Paths & lifecycle helpers for ephemeral/persistent databases
+
+Intended usage from the module registry:
+    eng = create_engine_for(str(db_path))
+    Session = session_factory_for(eng)
+    prepare_schema(eng)        # on first use or explicit "build"
+    # ...
+    drop_storage(db_path)      # explicit "drop"
+    eng = rebuild_storage(db_path)  # "rebuild"
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from sqlalchemy import String, create_engine, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Mapped, Session, declared_attr, mapped_column, sessionmaker
+
+from mug.common.infrastructure.orm import GUID, UTCDateTime, new_base
+
+
+# ---------------------------------------------------------------------------
+# ORM base & models (module-local)
+# ---------------------------------------------------------------------------
+
+Base = new_base()
+
+
+@dataclass
+class _AutoReprMixin:
+    """Optional dataclass-like repr for convenience (no behavioral impact)."""
+
+    def __repr__(self) -> str:  # pragma: no cover - convenience only
+        fields = ", ".join(f"{k}={v!r}" for k, v in vars(self).items())
+        return f"{self.__class__.__name__}({fields})"
+
+
+class Document(Base, _AutoReprMixin):
+    """Minimal document snapshot table (expand later as needed)."""
+
+    id: Mapped[str] = mapped_column(GUID(), primary_key=True)
+    title: Mapped[str] = mapped_column(String(256), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(UTCDateTime(), nullable=False)
+
+
+class MugMeta(Base, _AutoReprMixin):
+    """Key-value metadata for the module schema (versioning, timestamps)."""
+
+    __tablename__ = "mug_meta"
+
+    key: Mapped[str] = mapped_column(String(64), primary_key=True)
+    value: Mapped[str] = mapped_column(String(256), nullable=False)
+
+
+SCHEMA_VERSION = "1"
+
+
+# ---------------------------------------------------------------------------
+# Engine & session helpers
+# ---------------------------------------------------------------------------
+
+
+def make_sqlite_url(path: str) -> str:
+    """Return a SQLAlchemy connection URL for a given file path."""
+    if path == ":memory:":
+        # Use pysqlite driver for explicit in-memory DB
+        return "sqlite+pysqlite:///:memory:"
+    return f"sqlite:///{path}"
+
+
+def create_engine_for(path: str) -> Engine:
+    """Create a SQLAlchemy Engine for the given path (no side effects)."""
+    return create_engine(make_sqlite_url(path), future=True)
+
+
+def session_factory_for(engine: Engine):
+    """Return a configured session factory."""
+    return sessionmaker(bind=engine, expire_on_commit=False, future=True, class_=Session)
+
+
+# ---------------------------------------------------------------------------
+# Schema & metadata
+# ---------------------------------------------------------------------------
+
+
+def prepare_schema(engine: Engine) -> None:
+    """Create tables and seed schema metadata if needed."""
+    Base.metadata.create_all(bind=engine)
+
+    SessionLocal = session_factory_for(engine)
+    with SessionLocal() as s:
+        # Seed/refresh minimal metadata
+        s.execute(
+            text("insert or replace into mug_meta(key,value) values (:k,:v)"),
+            [
+                {"k": "schema_version", "v": SCHEMA_VERSION},
+                {
+                    "k": "built_at",
+                    "v": datetime.now(tz=timezone.utc).isoformat(),
+                },
+            ],
+        )
+        s.commit()
+
+
+def read_meta(session: Session) -> dict[str, str]:
+    """Read all key/value pairs from MugMeta."""
+    rows = session.execute(text("select key, value from mug_meta")).all()
+    return {k: v for (k, v) in rows}
+
+
+# ---------------------------------------------------------------------------
+# Paths & lifecycle
+# ---------------------------------------------------------------------------
+
+
+def default_ephemeral_path(base_dir: Optional[Path] = None) -> Path:
+    """Return a unique ephemeral DB path under .mug/run/documents/."""
+    root = (base_dir or Path(".mug") / "run" / "documents")
+    root.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    return (root / f"db-{ts}.sqlite").resolve()
+
+
+def persistent_path() -> Path:
+    """Return the persistent DB path under .mug/data/documents/."""
+    root = Path(".mug") / "data" / "documents"
+    root.mkdir(parents=True, exist_ok=True)
+    return (root / "documents.sqlite").resolve()
+
+
+def drop_storage(path: Path) -> None:
+    """Delete the SQLite file if present (caller must dispose engines)."""
+    try:
+        path.unlink(missing_ok=True)
+    except PermissionError:
+        # Ensure engine.dispose() was called by the caller before dropping on Windows.
+        pass
+
+
+def rebuild_storage(path: Path) -> Engine:
+    """Drop and recreate the storage file, returning a fresh Engine."""
+    # Dispose any existing engine for this path (caller responsibility).
+    drop_storage(path)
+    eng = create_engine_for(str(path))
+    prepare_schema(eng)
+    return eng

--- a/src/mug/modules/documents/presentation/documents/__init__.py
+++ b/src/mug/modules/documents/presentation/documents/__init__.py
@@ -1,0 +1,5 @@
+
+"""Documents.Presentation.Documents package.
+
+Holds CLI-facing presentation for document-related use cases (Typer commands).
+"""

--- a/src/mug/modules/documents/presentation/documents/cli.py
+++ b/src/mug/modules/documents/presentation/documents/cli.py
@@ -1,0 +1,79 @@
+"""Documents.Presentation.Documents: Typer CLI app builder.
+
+Builds the `documents` subcommand group with:
+- `trace-id` : generate a new trace/correlation id
+- `add`      : compute a deterministic XML path for a new document (no I/O)
+- `db` group : lifecycle helpers for the per-module SQLite store
+"""
+
+from __future__ import annotations
+
+import json
+import typer
+
+from mug.modules.documents.application.documents.get_trace_id.query import GetTraceIdQuery
+from mug.modules.documents.application.documents.add_document.command import AddDocumentCommand
+
+
+def build_documents_app(
+    *,
+    get_trace_id_handler_factory,
+    add_document_handler_factory,
+    registry,
+):
+    """Return a Typer app for the Documents module.
+
+    Args:
+        get_trace_id_handler_factory: callable that returns GetTraceIdHandler
+        add_document_handler_factory: callable that returns AddDocumentHandler
+        registry: module registry instance with DB lifecycle helpers
+                  (ensure_storage, engine(), session_factory(), db_path(),
+                   drop_storage(), rebuild_storage())
+    """
+    app = typer.Typer(name="documents", help="Documents module commands")
+
+    @app.command("trace-id", help="Generate a new trace/correlation id.")
+    def trace_id() -> None:
+        handler = get_trace_id_handler_factory()
+        typer.echo(handler.handle(GetTraceIdQuery()))
+
+    @app.command("add", help="Add a new document (stub: prints deterministic XML path).")
+    def add(
+        title: str = typer.Option(..., "--title", "-t", help="Document title"),
+        body: str | None = typer.Option(None, "--body", "-b", help="Optional body"),
+    ) -> None:
+        handler = add_document_handler_factory()
+        result_path = handler.handle(AddDocumentCommand(title=title, body=body))
+        typer.echo(json.dumps({"status": "ok", "path": result_path}))
+
+    # ---- DB lifecycle sub-commands ----
+    db = typer.Typer(name="db", help="Manage the Documents module SQLite store")
+
+    @db.command("build", help="Create tables/metadata if missing.")
+    def db_build() -> None:
+        registry.ensure_storage()
+        typer.echo("documents DB prepared")
+
+    @db.command("info", help="Show DB path and schema metadata.")
+    def db_info() -> None:
+        eng = registry.engine()
+        Session = registry.session_factory()
+        from mug.modules.documents.infrastructure.storage import read_meta  # local to avoid cycles
+
+        with Session() as s:
+            meta = read_meta(s)
+        typer.echo(json.dumps({"path": str(registry.db_path()), "meta": meta}))
+
+    @db.command("drop", help="Drop the current DB file.")
+    def db_drop() -> None:
+        # ensure engine is disposed by registry impl
+        registry.drop_storage()
+        typer.echo("documents DB dropped")
+
+    @db.command("rebuild", help="Drop and recreate the DB.")
+    def db_rebuild() -> None:
+        registry.rebuild_storage()
+        typer.echo("documents DB rebuilt")
+
+    app.add_typer(db)
+    return app

--- a/src/mug/modules/system/application/help/__init__.py
+++ b/src/mug/modules/system/application/help/__init__.py
@@ -1,0 +1,4 @@
+"""System.Application.Help package.
+
+Contains the GetHelp use case and related ports for discovering module commands.
+"""

--- a/src/mug/modules/system/application/help/get_help/__init__.py
+++ b/src/mug/modules/system/application/help/get_help/__init__.py
@@ -1,0 +1,5 @@
+"""GetHelp use case package.
+
+Formats a human-friendly list of available module commands using the
+CommandCatalog port provided by the composition root.
+"""

--- a/src/mug/modules/system/application/help/get_help/handler.py
+++ b/src/mug/modules/system/application/help/get_help/handler.py
@@ -1,0 +1,24 @@
+"""System.Application.Help.GetHelp handler.
+
+Uses the CommandCatalog port to build a human-friendly list of available
+module commands. Kept free of Presentation/Infrastructure concerns.
+"""
+
+from __future__ import annotations
+
+from mug.modules.system.application.help.ports import CommandCatalog
+
+
+class GetHelpHandler:
+    """Formats a list of module commands from the provided catalog."""
+
+    def __init__(self, catalog: CommandCatalog) -> None:
+        self._catalog = catalog
+
+    def handle(self) -> str:
+        mapping = self._catalog.list_commands()
+        lines: list[str] = ["Available module commands:"]
+        for module in sorted(mapping.keys()):
+            cmds = [str(c) for c in mapping.get(module, [])]
+            lines.append(f"  {module}: {', '.join(cmds) if cmds else '(none)'}")
+        return "\n".join(lines)

--- a/src/mug/modules/system/application/help/ports.py
+++ b/src/mug/modules/system/application/help/ports.py
@@ -1,0 +1,15 @@
+"""System.Application.Help: command discovery port.
+
+This port abstracts how the System module discovers module -> commands mappings.
+The composition root (CLI) provides an implementation (e.g., StaticCommandCatalog)
+to avoid cross-module knowledge leaking into System.
+"""
+
+from typing import Protocol
+
+
+class CommandCatalog(Protocol):
+    """Abstraction for discovering available commands per module."""
+
+    def list_commands(self) -> dict[str, list[str]]:
+        """Return a mapping like: {'documents': ['trace-id', 'add', 'db'], ...}."""

--- a/src/mug/modules/system/application/ports/system_info_reader.py
+++ b/src/mug/modules/system/application/ports/system_info_reader.py
@@ -1,0 +1,16 @@
+"""System.Application.Ports: SystemInfoReader port.
+
+Abstraction for reading system metadata (version, build/run info).
+Implemented in Infrastructure (e.g., reading from package metadata/env).
+"""
+
+from typing import Protocol
+
+from mug.modules.system.domain.system_info.entity import SystemInfo
+
+
+class SystemInfoReader(Protocol):
+    """Port that supplies a snapshot of system information."""
+
+    def get_system_info(self) -> SystemInfo:
+        """Return the current SystemInfo snapshot."""

--- a/src/mug/modules/system/application/version/__init__.py
+++ b/src/mug/modules/system/application/version/__init__.py
@@ -1,0 +1,4 @@
+"""System.Application.Version package.
+
+Contains the GetVersion use case (query + handler).
+"""

--- a/src/mug/modules/system/application/version/get_version/__init__.py
+++ b/src/mug/modules/system/application/version/get_version/__init__.py
@@ -1,0 +1,4 @@
+"""GetVersion use case package.
+
+Defines the query DTO and handler for retrieving the application's version.
+"""

--- a/src/mug/modules/system/application/version/get_version/handler.py
+++ b/src/mug/modules/system/application/version/get_version/handler.py
@@ -1,0 +1,17 @@
+"""System.Application.Version.GetVersion handler.
+
+Reads the system's semantic version via the SystemInfoReader port.
+"""
+
+from mug.modules.system.application.ports.system_info_reader import SystemInfoReader
+from .query import GetVersionQuery
+
+
+class GetVersionHandler:
+    """Returns the application's version string."""
+
+    def __init__(self, reader: SystemInfoReader) -> None:
+        self._reader = reader
+
+    def handle(self, _: GetVersionQuery) -> str:
+        return self._reader.get_system_info().version.value

--- a/src/mug/modules/system/application/version/get_version/query.py
+++ b/src/mug/modules/system/application/version/get_version/query.py
@@ -1,0 +1,8 @@
+"""System.Application.Version.GetVersion: query DTO."""
+
+from pydantic import BaseModel
+
+
+class GetVersionQuery(BaseModel):
+    """Empty query DTO for symmetry with other use cases."""
+    pass

--- a/src/mug/modules/system/domain/system_info/entity.py
+++ b/src/mug/modules/system/domain/system_info/entity.py
@@ -1,0 +1,31 @@
+"""System.Domain.SystemInfo: immutable snapshot of system metadata."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from .version import Version
+
+
+@dataclass(frozen=True)
+class SystemInfo:
+    """Immutable system information aggregate.
+
+    Captures the running application's identity and build/runtime metadata.
+    This is a pure domain structure—no I/O, no infrastructure concerns.
+
+    Attributes:
+        version: semantic version of the running application.
+        built_at: build timestamp (UTC) if available.
+        started_at: process start timestamp (UTC) if available.
+        commit: source control commit hash, if embedded.
+        name: logical application name (e.g., package name).
+    """
+
+    version: Version
+    built_at: Optional[datetime] = None
+    started_at: Optional[datetime] = None
+    commit: Optional[str] = None
+    name: Optional[str] = None

--- a/src/mug/modules/system/domain/system_info/version.py
+++ b/src/mug/modules/system/domain/system_info/version.py
@@ -1,0 +1,49 @@
+"""System.Domain.SystemInfo: semantic Version value object."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from mug.common.domain.value_object import ValueObject
+
+
+# Basic SemVer: MAJOR.MINOR.PATCH with optional -prerelease and +build
+_SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?"
+    r"(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+)
+
+
+@dataclass(frozen=True)
+class Version(ValueObject):
+    """Immutable semantic version.
+
+    Examples:
+        1.0.0
+        2.1.3-alpha.1
+        0.9.0+build.5
+        3.2.1-rc.2+20240904
+    """
+    value: str
+
+    def __post_init__(self) -> None:
+        if not _SEMVER_RE.match(self.value or ""):
+            raise ValueError(f"Invalid semantic version: {self.value!r}")
+
+    # Convenience accessors ---------------------------------------------------
+    @property
+    def major(self) -> int:
+        return int(_SEMVER_RE.match(self.value).group(1))  # type: ignore[union-attr]
+
+    @property
+    def minor(self) -> int:
+        return int(_SEMVER_RE.match(self.value).group(2))  # type: ignore[union-attr]
+
+    @property
+    def patch(self) -> int:
+        return int(_SEMVER_RE.match(self.value).group(3))  # type: ignore[union-attr]
+
+    def __str__(self) -> str:  # pragma: no cover - convenience
+        return self.value

--- a/src/mug/modules/system/infrastructure/registry.py
+++ b/src/mug/modules/system/infrastructure/registry.py
@@ -1,0 +1,31 @@
+# src/mug/modules/system/infrastructure/registry.py
+from dependency_injector import containers, providers
+
+from mug.modules.system.infrastructure.system_info_reader import PackageSystemInfoReader
+from mug.modules.system.application.version.get_version.handler import GetVersionHandler
+from mug.modules.system.application.help.get_help.handler import GetHelpHandler
+from mug.modules.system.application.help.ports import CommandCatalog
+
+class SystemRegistry(containers.DeclarativeContainer):
+    """System module container."""
+    config = providers.Configuration()
+
+    # Infrastructure adapters
+    system_info_reader = providers.Factory(
+        PackageSystemInfoReader,
+        package_name="mug",
+    )
+
+    # Application handlers
+    get_version_handler = providers.Factory(
+        GetVersionHandler,
+        reader=system_info_reader,
+    )
+
+    # Provided by composition root to avoid cross-module leakage
+    command_catalog = providers.Dependency(instance_of=CommandCatalog)
+
+    get_help_handler = providers.Factory(
+        GetHelpHandler,
+        catalog=command_catalog,
+    )

--- a/src/mug/modules/system/infrastructure/system_info_reader.py
+++ b/src/mug/modules/system/infrastructure/system_info_reader.py
@@ -1,0 +1,76 @@
+"""System.Infrastructure: SystemInfoReader implementation.
+
+Reads version/build/runtime metadata from Python package metadata and environment:
+
+- version: importlib.metadata.version(<package>)  (fallback "0.0.0" if missing/invalid)
+- built_at: ISO-8601 timestamp from env BUILD_AT (optional)
+- started_at: process start time (UTC)
+- commit: env GIT_COMMIT (optional)
+- name: env APP_NAME or the package name
+
+This keeps all I/O and environment access in Infrastructure.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError, version as pkg_version
+from typing import Optional
+
+from mug.modules.system.application.ports.system_info_reader import SystemInfoReader
+from mug.modules.system.domain.system_info.entity import SystemInfo
+from mug.modules.system.domain.system_info.version import Version
+
+
+class PackageSystemInfoReader(SystemInfoReader):
+    """Reads system information from package metadata and environment."""
+
+    def __init__(self, package_name: str = "mug") -> None:
+        self._package_name = package_name
+        self._started_at = datetime.fromtimestamp(time.time(), tz=timezone.utc)
+
+    # ---- Port implementation ------------------------------------------------
+
+    def get_system_info(self) -> SystemInfo:
+        ver_str = self._read_version(self._package_name) or "0.0.0"
+        version = self._coerce_semver(ver_str) or Version("0.0.0")
+        return SystemInfo(
+            version=version,
+            built_at=self._parse_iso(os.getenv("BUILD_AT")),
+            started_at=self._started_at,
+            commit=os.getenv("GIT_COMMIT"),
+            name=os.getenv("APP_NAME") or self._package_name,
+        )
+
+    # ---- Helpers ------------------------------------------------------------
+
+    def _read_version(self, package: str) -> Optional[str]:
+        try:
+            return pkg_version(package)
+        except PackageNotFoundError:
+            return None
+        except Exception:
+            # Defensive: if metadata is corrupted, treat as unknown
+            return None
+
+    def _coerce_semver(self, raw: str) -> Optional[Version]:
+        try:
+            return Version(raw)
+        except Exception:
+            return None
+
+    def _parse_iso(self, s: Optional[str]) -> Optional[datetime]:
+        if not s:
+            return None
+        try:
+            # Accept 'Z' suffix as UTC
+            if s.endswith("Z"):
+                s = s[:-1] + "+00:00"
+            dt = datetime.fromisoformat(s)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.astimezone(timezone.utc)
+        except Exception:
+            return None

--- a/src/mug/modules/system/infrastructure/system_module.py
+++ b/src/mug/modules/system/infrastructure/system_module.py
@@ -1,0 +1,15 @@
+
+from dependency_injector import providers
+
+from mug.cli.container import AppContainer
+from mug.modules.system.application.help.ports import CommandCatalog
+from .registry import SystemRegistry  # <-- delegate to the canonical registry
+
+def add_system_module(services: AppContainer, *, command_catalog: CommandCatalog) -> None:
+    """Register the System module into the root container (IServiceCollection analogue)."""
+    system = providers.Container(
+        SystemRegistry,
+        config=services.config.modules.system,
+        command_catalog=providers.Object(command_catalog),
+    )
+    services.system.override(system)


### PR DESCRIPTION
* update `src/mug/cli/__main__.py` to act as composition root and mount module CLIs two modules are plugged via `add_system_module` and `add_documents_module`

* add `src/mug/cli/container.py` to host DI providers used by common and modules

* add `src/mug/cli/help_catalog.py` to expose a composition-owned command catalog

* add common application primitives in `common/application` (`time.py`, `trace.py`, `result.py`, `pipeline.py`, `paging.py`, `bootstrap.py`) to standardize use cases

* add common domain bases in `common/domain` (`entity.py`, `value_object.py`, `events.py`, `errors.py`) to mirror the golden example ddd layer

* add common presentation in `common/presentation` (`output.py`, `cli_presenters.py`) to render `Result` and problems consistently for the cli

* add common infrastructure bootstrap in `common/infrastructure/bootstrap.py` and bind `SystemClock` and `LoggingInitializer` implementations

* add orm helpers in `common/infrastructure/orm` (`__init__.py`, `factory.py`, `types.py`) for per-module declarative bases and portable types

* add system module: ports, version and help handlers, package-based `SystemInfoReader`, and DI registry in `modules/system/infrastructure/registry.py`

* add documents module: feature folders for `get_trace_id` and `add_document` use cases, sqlite storage adapter, and DI registry in `modules/documents/infrastructure/registry.py`

* wire module entrypoints from the composition root to mirror the .net “*Module” pattern via `add_system_module` and `add_documents_module`

* expose documents subcommands (`trace-id`, `add`, `db`) through the module cli builder

* update `docs/TESTING_POLICY.md`